### PR TITLE
API update: Conversion of ext adc to mV and bug fix

### DIFF
--- a/scientisst/scientisst.py
+++ b/scientisst/scientisst.py
@@ -28,14 +28,6 @@ class ScientISST:
         serial_speed (int, optional): The serial port bitrate.
     """
 
-    __serial = None
-    __socket = None
-    __num_chs = 0
-    __api_mode = 1
-    __sample_rate = None
-    __chs = [None] * 8
-    __log = False
-
     def __init__(
         self,
         address,
@@ -643,8 +635,12 @@ class ScientISST:
         """
         result = None
         if self.__socket:
+            result = bytearray()
+            remaining = nrOfBytes
             if waitall_flag:
-                result = self.__socket.recv(nrOfBytes, socket.MSG_WAITALL)
+                while remaining > 0:
+                    result.extend(self.__socket.recv(remaining))
+                    remaining = nrOfBytes - len(result)
             else:
                 result = self.__socket.recv(nrOfBytes)
         elif self.__serial:

--- a/scientisst/scientisst.py
+++ b/scientisst/scientisst.py
@@ -654,7 +654,6 @@ class ScientISST:
                         ready = select.select([self.__socket], [], [], 10)
                         if not ready[0]:
                             raise ContactingDeviceError()
-                            break
                         temp = self.__socket.recv(remaining)
                         result += temp
                         remaining = nrOfBytes - len(result)

--- a/scientisst/scientisst.py
+++ b/scientisst/scientisst.py
@@ -64,6 +64,13 @@ class ScientISST:
         self.address = address
         self.serial_speed = serial_speed
         self.__log = log
+        #changed this from class attributes to instance attributes so user can change settings within the same script
+        self.serial = None
+        self.socket = None
+        self.num_chs = 0
+        self.api_mode = 1
+        self.sample_rate = None
+        self.chs = [None] * 8
 
         # Setup socket in function of com_mode argument
         self.__setupSocket()
@@ -284,6 +291,9 @@ class ScientISST:
                             & 0xFFFFFF
                         )
                         byte_it += 3
+                        if convert:
+                            f.mv[index] = (f.a[index]) * (3.3*2) / (pow(2, 24) - 1)
+                            f.mv[index] = round(f.mv[index]*1000, 3)
 
                     # If it's an AI channel
                     else:


### PR DESCRIPTION
API update with the following changes:
-Updated the API so that the ext adc channels are also converted to mV;
-Fixed a bug where the API didn't recognize that a device disconnected unexpectedly and would hang indefinitely when using tcp_sta communication mode. Now API throws a ContactingDeviceError() when socket timesout (10 seconds).